### PR TITLE
Fix useKeyboard initial state

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -22,6 +22,8 @@ jest.mock("react-native", () => {
 		},
                 Keyboard: (() => {
                         const listeners = new Map()
+                        let visible = false
+                        let metrics
                         return {
                                 addListener: jest.fn((event, cb) => {
                                         listeners.set(event, cb)
@@ -32,7 +34,17 @@ jest.mock("react-native", () => {
                                 emit: jest.fn((event, data) => {
                                         const cb = listeners.get(event)
                                         if (cb) cb(data)
+                                        if (event === "keyboardDidShow") {
+                                                visible = true
+                                                metrics = data?.endCoordinates
+                                        }
+                                        if (event === "keyboardDidHide") {
+                                                visible = false
+                                                metrics = undefined
+                                        }
                                 }),
+                                isVisible: jest.fn(() => visible),
+                                metrics: jest.fn(() => metrics),
                         }
                 })(),
 		AccessibilityInfo: {

--- a/src/useKeyboard.test.ts
+++ b/src/useKeyboard.test.ts
@@ -3,16 +3,22 @@ import { act, renderHook } from "@testing-library/react-hooks/native"
 import { Keyboard } from "react-native"
 
 describe("useKeyboard", () => {
-	const mockCoords = { screenX: 0, screenY: 0, width: 0, height: 0 }
-	const emitKeyboardEvent = ({
-		show = true,
-		startCoordinates = mockCoords,
-		endCoordinates = mockCoords,
-	}) => {
-		const mockEvent = { startCoordinates, endCoordinates }
+        const mockCoords = { screenX: 0, screenY: 0, width: 0, height: 0 }
+        const emitKeyboardEvent = ({
+                show = true,
+                startCoordinates = mockCoords,
+                endCoordinates = mockCoords,
+        }) => {
+                const mockEvent = { startCoordinates, endCoordinates }
 
-		Keyboard.emit(show ? "keyboardDidShow" : "keyboardDidHide", show ? mockEvent : null)
-	}
+                Keyboard.emit(show ? "keyboardDidShow" : "keyboardDidHide", show ? mockEvent : null)
+        }
+
+        afterEach(() => {
+                act(() => {
+                        emitKeyboardEvent({ show: false })
+                })
+        })
 
 	describe("setKeyboardHeight: number", () => {
 		it("keyboard height is zero by default", () => {
@@ -50,12 +56,24 @@ describe("useKeyboard", () => {
 		})
 	})
 
-	describe("keyboardShown: boolean", () => {
-		it("keyboard closed by default", () => {
-			const { result } = renderHook(() => useKeyboard())
+        describe("keyboardShown: boolean", () => {
+                it("keyboard closed by default", () => {
+                        const { result } = renderHook(() => useKeyboard())
 
-			expect(result.current.keyboardShown).toBe(false)
-		})
+                        expect(result.current.keyboardShown).toBe(false)
+                })
+
+                it("should detect already opened keyboard on mount", () => {
+                        const height = 100
+                        act(() => {
+                                emitKeyboardEvent({ show: true, endCoordinates: { ...mockCoords, height } })
+                        })
+
+                        const { result } = renderHook(() => useKeyboard())
+
+                        expect(result.current.keyboardShown).toBe(true)
+                        expect(result.current.keyboardHeight).toBe(height)
+                })
 
 		it("should set keyboardShown when keyboard will open", () => {
 			const { result } = renderHook(() => useKeyboard())

--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -13,12 +13,22 @@ const initialValue = {
 }
 
 export function useKeyboard() {
-	const [shown, setShown] = useState(false)
-	const [coordinates, setCoordinates] = useState<{
-		start: undefined | KeyboardMetrics
-		end: KeyboardMetrics
-	}>(initialValue)
-	const [keyboardHeight, setKeyboardHeight] = useState<number>(0)
+        const initialMetrics = typeof Keyboard.metrics === "function" ? Keyboard.metrics() : undefined
+        const [shown, setShown] = useState(() => {
+                if (typeof Keyboard.isVisible === "function") {
+                        try {
+                                return Keyboard.isVisible()
+                        } catch {
+                                return false
+                        }
+                }
+                return false
+        })
+        const [coordinates, setCoordinates] = useState<{
+                start: undefined | KeyboardMetrics
+                end: KeyboardMetrics
+        }>(() => (initialMetrics ? { start: undefined, end: initialMetrics } : initialValue))
+        const [keyboardHeight, setKeyboardHeight] = useState<number>(() => initialMetrics?.height ?? 0)
 
 	const handleKeyboardWillShow: KeyboardEventListener = (e) => {
 		setCoordinates({ start: e.startCoordinates, end: e.endCoordinates })


### PR DESCRIPTION
## Summary
- check `Keyboard.isVisible()` and `Keyboard.metrics()` when initializing
- extend Keyboard mock to track visibility and metrics
- reset keyboard between tests and add a new test verifying mount while keyboard is open

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_684a7c8df6d08329b3bae8c204ab853b